### PR TITLE
Update __init__.py

### DIFF
--- a/mccmnc/__init__.py
+++ b/mccmnc/__init__.py
@@ -1,0 +1,1 @@
+from .mccmnc import find_matches, print_matches, update


### PR DESCRIPTION
Fixed `ImportError: cannot import name 'find_matches' from 'mccmnc'`

is mccmnc.json supposed to ship with `pip install mccmnc`